### PR TITLE
Only require codecov when needed

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,8 +2,8 @@ require 'simplecov'
 SimpleCov.start 'rails' do
   add_filter "/test/"
 end
-require 'codecov'
 if ENV['CI'] == 'true'
+  require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 


### PR DESCRIPTION
…and keep it in sync with the Ruby Setup Guide
