### PR TITLE
ensure at least codecov version 0.1.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    codecov (0.0.1)
+    codecov (0.1.10)
       json
       simplecov
       url
     docile (1.1.5)
-    json (1.8.1)
+    json (2.1.0)
     metaclass (0.0.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -29,7 +29,10 @@ PLATFORMS
 
 DEPENDENCIES
   awesome!
-  codecov
+  codecov (>= 0.1.10)
   mocha
   rake
   simplecov
+
+BUNDLED WITH
+   1.12.5

--- a/awesome.gemspec
+++ b/awesome.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "mocha"
   s.add_development_dependency "rake"
-  s.add_development_dependency "codecov"
+  s.add_development_dependency "codecov", ">= 0.1.10"
 
 end


### PR DESCRIPTION
Was attempting to just bundle this locally and it didn't seem to work because of a version of `json` not loading properly with ruby 2.3 (json version 1.8.1). Seems like keeping it to at least this version of the codecov gem works well.

@TomPed @stevepeak for review ❤️ 